### PR TITLE
Bump conscrypt to 2.6.1 and release 1.10.2

### DIFF
--- a/Changelogs/1.10.2
+++ b/Changelogs/1.10.2
@@ -1,0 +1,6 @@
+1.10.2 Release notes (2026-07-23)
+=============================================================
+
+### Changes
+
+* Updated conscrypt to 2.6.1 (latest stable; native libraries stay 16 KB page-aligned for Android 15+)

--- a/RingPublishingGDPR/build.gradle
+++ b/RingPublishingGDPR/build.gradle
@@ -91,7 +91,9 @@ dependencies
     api "com.squareup.retrofit2:converter-gson:2.9.0"
 
     // Fix for missing conscrypt hostname verifier in logs
-    api 'org.conscrypt:conscrypt-android:2.5.3'
+    // 2.6.1 aligns the native libconscrypt_jni.so to 16 KB page size (Android 15+ requirement,
+    // clears the Google Play Console 16 KB page-size warning)
+    api 'org.conscrypt:conscrypt-android:2.6.1'
 
     // Core library
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,5 @@ android.enableJetifier=true
 # Remember create changelog file before publish_open_source_sdk
 # TO change this manually use gradle method bumpPatchVersion bumpMinorVersion bumpMajorVersion
 
-sdk_version_name=1.10.1
-sdk_version_code=30
+sdk_version_name=1.10.2
+sdk_version_code=31


### PR DESCRIPTION
## What

Bumps `org.conscrypt:conscrypt-android` from **2.5.3 → 2.6.1** (latest stable) and cuts patch release **1.10.2** (versionCode 31).

## Why

Routine dependency refresh to the latest conscrypt. 2.6.1 keeps the native `libconscrypt_jni.so` 16 KB page-size aligned for Android 15+ / Google Play.

Low risk — verified that the native `.so` ELF segment alignment (`2**14`) and the APK packaging (`STORED` + `zipalign -P 16` OK) are unchanged versus 2.5.3, so no behavioural change is expected.

## Changes

- `RingPublishingGDPR/build.gradle` — conscrypt `2.5.3` → `2.6.1`
- `gradle.properties` — `sdk_version_name` `1.10.1` → `1.10.2`, `sdk_version_code` `30` → `31`
- `Changelogs/1.10.2` — release notes

## Verification

- `./gradlew :RingPublishingGDPR:assemble` → BUILD SUCCESSFUL, resolves `conscrypt-android:2.6.1`
- Demo app builds, installs and launches on an Android emulator (`MainActivity` renders correctly)

## Deployment

After merge to `master`, `1.10.2` is released via the `publish_open_source_sdk` fastlane lane (git tag `1.10.2`, GitHub Packages `com.ringpublishing:gdpr:1.10.2`, GitHub Release). The deployment will be triggered manually.
